### PR TITLE
Adding isInsideByLocation to AbstractShapeMarker

### DIFF
--- a/src/de/fhpotsdam/unfolding/marker/AbstractShapeMarker.java
+++ b/src/de/fhpotsdam/unfolding/marker/AbstractShapeMarker.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import processing.core.PGraphics;
+import processing.core.PVector;
 import de.fhpotsdam.unfolding.UnfoldingMap;
 import de.fhpotsdam.unfolding.geo.Location;
 import de.fhpotsdam.unfolding.utils.GeoUtils;
@@ -164,17 +165,31 @@ public abstract class AbstractShapeMarker extends AbstractMarker {
 		return isInside(checkX, checkY, positions);
 	}
 
-	protected boolean isInside(float checkX, float checkY, List<ScreenPosition> positions) {
+	protected boolean isInside(float checkX, float checkY,
+			List<? extends PVector> vectors) {
 		boolean inside = false;
-		for (int i = 0, j = positions.size() - 1; i < positions.size(); j = i++) {
-			ScreenPosition pi = positions.get(i);
-			ScreenPosition pj = positions.get(j);
+		for (int i = 0, j = vectors.size() - 1; i < vectors.size(); j = i++) {
+			PVector pi = vectors.get(i);
+			PVector pj = vectors.get(j);
 			if ((((pi.y <= checkY) && (checkY < pj.y)) || ((pj.y <= checkY) && (checkY < pi.y)))
 					&& (checkX < (pj.x - pi.x) * (checkY - pi.y) / (pj.y - pi.y) + pi.x)) {
 				inside = !inside;
 			}
 		}
 		return inside;
+	}
+
+	/**
+	 * Checks whether given position is inside this marker, according to the
+	 * shape defined by the marker's locations
+	 * 
+	 * @param longitude
+	 *            The longitude
+	 * @param latitude
+	 *            The latitude
+	 */
+	public boolean isInsideByLocation(float latitude, float longitude) {
+		return isInside(latitude, longitude, locations);
 	}
 
 	@Override

--- a/src/de/fhpotsdam/unfolding/marker/Marker.java
+++ b/src/de/fhpotsdam/unfolding/marker/Marker.java
@@ -70,7 +70,9 @@ public interface Marker {
 
 
 	/**
-	 * Checks whether given position is inside this marker, according to the maps coordinate system.
+	 * Checks whether given position is inside this marker, according to the
+	 * maps coordinate system. Can be used for interactive hit tests, e.g. mouse
+	 * interaction
 	 * 
 	 * @param map
 	 *            The map to draw on.

--- a/test/de/fhpotsdam/AbstractShapeMarkerLocationTest.java
+++ b/test/de/fhpotsdam/AbstractShapeMarkerLocationTest.java
@@ -1,0 +1,50 @@
+package de.fhpotsdam;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import processing.core.PApplet;
+import de.fhpotsdam.unfolding.UnfoldingMap;
+import de.fhpotsdam.unfolding.geo.Location;
+import de.fhpotsdam.unfolding.marker.Marker;
+import de.fhpotsdam.unfolding.marker.MarkerManager;
+import de.fhpotsdam.unfolding.marker.SimplePolygonMarker;
+
+public class AbstractShapeMarkerLocationTest {
+
+	private UnfoldingMap map;
+	private MarkerManager<Marker> markerManager = new MarkerManager<Marker>();
+	private SimplePolygonMarker marker;
+	private float squareWidth = 10.f;
+
+	@Before
+	public void before() {
+		map = new UnfoldingMap(new PApplet());
+		map.addMarkerManager(markerManager);
+		addSquareMarker();
+	}
+
+	private void addSquareMarker() {
+		ArrayList<Location> list = new ArrayList<Location>();
+		list.add(new Location(0, 0));
+		list.add(new Location(0, squareWidth));
+		list.add(new Location(squareWidth, squareWidth));
+		list.add(new Location(squareWidth, 0));
+		marker = new SimplePolygonMarker(list);
+		markerManager.addMarker(marker);
+	}
+
+	@Test
+	public void test() {
+		assertTrue(marker.isInsideByLocation(squareWidth / 2.0f,
+				squareWidth / 2.0f));
+		assertFalse(marker.isInsideByLocation(-1, -1));
+		assertFalse(marker.isInsideByLocation(squareWidth + 1, squareWidth + 1));
+	}
+
+}


### PR DESCRIPTION
This addresses issue #49. It has been closed since, although I can't seem to find a relevant method on any of the marker classes or any utils class that lets you check if a lat/long lies inside a shape marker.
