### PR TITLE
Make the MarkerManager's attributes protected

### DIFF
--- a/src/de/fhpotsdam/unfolding/marker/MarkerManager.java
+++ b/src/de/fhpotsdam/unfolding/marker/MarkerManager.java
@@ -10,8 +10,8 @@ import de.fhpotsdam.unfolding.UnfoldingMap;
  */
 public class MarkerManager<E extends Marker> {
 
-	UnfoldingMap map;
-	List<E> markers;
+	protected UnfoldingMap map;
+	protected List<E> markers;
 	protected boolean bEnableDrawing;
 
 	/**


### PR DESCRIPTION
I wanted to subclass MarkerManager, but found it difficult. By making these attributes both protected it was easier for me to hook into what I needed. 
