### PR TITLE
toner-lite map provider url was incorrect

### DIFF
--- a/src/de/fhpotsdam/unfolding/providers/StamenMapProvider.java
+++ b/src/de/fhpotsdam/unfolding/providers/StamenMapProvider.java
@@ -22,7 +22,7 @@ public class StamenMapProvider extends OpenStreetMapProvider {
 
 	public static class TonerLite extends GenericOpenStreetMapProvider {
 		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://tile.stamen.com/toner-background/" + getZoomString(coordinate) + ".png";
+			String url = "http://tile.stamen.com/toner-lite/" + getZoomString(coordinate) + ".png";
 			return new String[] { url };
 		}
 	}


### PR DESCRIPTION
updated StamenMapProvider.TonerLite url from http://tile.stamen.com/toner-background to http://tile.stamen.com/toner-lite
