### PR TITLE
Updated OpenStreetMap providers

### DIFF
--- a/examples/de/fhpotsdam/unfolding/examples/provider/dynamic/DynamicProviderSwitch.java
+++ b/examples/de/fhpotsdam/unfolding/examples/provider/dynamic/DynamicProviderSwitch.java
@@ -52,7 +52,7 @@ public class DynamicProviderSwitch extends PApplet {
 	}
 	
 	public static void main(String[] args) {
-		PApplet.main(new String[] { DynamicMapSwitch.class.getName() });
+		PApplet.main(new String[] { DynamicProviderSwitch.class.getName() });
 	}
 
 }

--- a/examples/de/fhpotsdam/unfolding/examples/provider/dynamic/DynamicProviderSwitch.java
+++ b/examples/de/fhpotsdam/unfolding/examples/provider/dynamic/DynamicProviderSwitch.java
@@ -50,5 +50,9 @@ public class DynamicProviderSwitch extends PApplet {
 			map.mapDisplay.setProvider(provider3);
 		}
 	}
+	
+	public static void main(String[] args) {
+		PApplet.main(new String[] { DynamicMapSwitch.class.getName() });
+	}
 
 }

--- a/src/de/fhpotsdam/unfolding/mapdisplay/MapDisplayFactory.java
+++ b/src/de/fhpotsdam/unfolding/mapdisplay/MapDisplayFactory.java
@@ -52,7 +52,6 @@ public class MapDisplayFactory {
 	}
 
 	public static AbstractMapProvider getDefaultProvider() {
-		//return new OpenStreetMap.OSMGrayProvider();
-		return new OpenStreetMap.PositronMapProvider();
+		return new OpenStreetMap.OSMGrayProvider();
 	}
 }

--- a/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
+++ b/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
@@ -43,20 +43,6 @@ public class OpenStreetMap {
 			return new String[] { url };
 		}
 	}
-	
-	public static class PositronMapProvider extends GenericOpenStreetMapProvider {
-		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://a.basemaps.cartocdn.com/light_all/" + getZoomString(coordinate) + ".png";
-			return new String[] { url };
-		}
-	}
-	
-	public static class DarkMatterMapProvider extends GenericOpenStreetMapProvider {
-		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://a.basemaps.cartocdn.com/dark_all/" + getZoomString(coordinate) + ".png";
-			return new String[] { url };
-		}
-	}
 
 	/**
 	 * Map tiles with custom styled maps via CloudMade with OpenStreetMap data.

--- a/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
+++ b/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
@@ -32,14 +32,14 @@ public class OpenStreetMap {
 
 	public static class OpenStreetMapProvider extends GenericOpenStreetMapProvider {
 		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://tile.openstreetmap.org/" + getZoomString(coordinate) + ".png";
+			String url = "http://a.tile.openstreetmap.org/" + getZoomString(coordinate) + ".png";
 			return new String[] { url };
 		}
 	}
 
 	public static class OSMGrayProvider extends GenericOpenStreetMapProvider {
 		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://a.www.toolserver.org/tiles/bw-mapnik/" + getZoomString(coordinate) + ".png";
+			String url = "http://a.tiles.wmflabs.org/bw-mapnik2/" + getZoomString(coordinate) + ".png";
 			return new String[] { url };
 		}
 	}
@@ -47,6 +47,13 @@ public class OpenStreetMap {
 	public static class PositronMapProvider extends GenericOpenStreetMapProvider {
 		public String[] getTileUrls(Coordinate coordinate) {
 			String url = "http://a.basemaps.cartocdn.com/light_all/" + getZoomString(coordinate) + ".png";
+			return new String[] { url };
+		}
+	}
+	
+	public static class DarkMatterMapProvider extends GenericOpenStreetMapProvider {
+		public String[] getTileUrls(Coordinate coordinate) {
+			String url = "http://a.basemaps.cartocdn.com/dark_all/" + getZoomString(coordinate) + ".png";
 			return new String[] { url };
 		}
 	}


### PR DESCRIPTION
Some tile URLs have changed, which broke or slowed down the OSM providers. I updated the URLs and removed a redundant provider. Also added a main method to the DynamicProviderSwitch example, since the lack of one caused problems when trying to test the new URLs.