### PR TITLE
replaces "toolserver" URL with openstreetmap URL.

### DIFF
--- a/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
+++ b/src/de/fhpotsdam/unfolding/providers/OpenStreetMap.java
@@ -39,7 +39,7 @@ public class OpenStreetMap {
 
 	public static class OSMGrayProvider extends GenericOpenStreetMapProvider {
 		public String[] getTileUrls(Coordinate coordinate) {
-			String url = "http://a.www.toolserver.org/tiles/bw-mapnik/" + getZoomString(coordinate) + ".png";
+			String url = "http://tile.openstreetmap.org/" + getZoomString(coordinate) + ".png";
 			return new String[] { url };
 		}
 	}


### PR DESCRIPTION
 Toolserver link is broken. "bw-mapnik" directory no longer exists.